### PR TITLE
Tooltip and Area Click Behavior Updates

### DIFF
--- a/lib/plox.ex
+++ b/lib/plox.ex
@@ -304,7 +304,6 @@ defmodule Plox do
 
   attr :dataset, :any, required: true
   attr :point_id, :any, required: true
-
   attr :x, :atom, default: :x, doc: "The dataset axis key to use for x values"
   attr :y, :atom, default: :y, doc: "The dataset axis key to use for y values"
 
@@ -316,8 +315,7 @@ defmodule Plox do
   def tooltip(assigns) do
     point = GraphDataset.to_graph_point(assigns.dataset, assigns.x, assigns.y, assigns.point_id)
 
-    assigns =
-      assign(assigns, point: point)
+    assigns = assign(assigns, point: point)
 
     ~H"""
     <div
@@ -335,6 +333,44 @@ defmodule Plox do
     """
   end
 
+  # @doc """
+  # TODO:
+
+  # Tooltip based on manually passing y/y scales/values instead of inferring based on dataset.
+  # """
+  # @doc type: :component
+
+  # attr :x_scale, :any, required: true
+  # attr :y_scale, :any, required: true
+  # attr :x_value, :any, required: true
+  # attr :y_value, :any, required: true
+
+  # attr :"phx-click-away", :any
+  # attr :"phx-target", :any, default: nil
+
+  # slot :inner_block, required: true
+
+  # def coordinate_tooltip(assigns) do
+  #   point = GraphDataset.to_graph_point(assigns.dataset, assigns.x, assigns.y, assigns.point_id)
+
+  #   assigns = assign(assigns, point: point)
+
+  #   ~H"""
+  #   <div
+  #     style={[
+  #       "position: absolute; padding: 1rem; font-size: 0.75rem; background: #4B4C4D; color: #CACBCC; z-index: 10; border-radius: 0.75rem; transform: translate(-50%);",
+  #       "left: #{@point.x}px; bottom: #{@dataset.dimensions.height - @point.y + 12}px;",
+  #       "box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1);"
+  #     ]}
+  #     phx-click-away={assigns[:"phx-click-away"]}
+  #     phx-target={assigns[:"phx-target"]}
+  #   >
+  #     <%= render_slot(@inner_block, @point.data_point.original) %>
+  #     <div style="transform: translate(-50%) rotate(45deg); position: absolute; left: 50%; bottom: -0.5rem; width: 1rem; height: 1rem; z-index: -10; background: #4B4C4D" />
+  #   </div>
+  #   """
+  # end
+
   @doc """
   One-dimensional shaded areas, either horizontal or vertical
   """
@@ -346,6 +382,9 @@ defmodule Plox do
   attr :color, :atom, required: true, doc: "The dataset axis key to use for colors"
 
   attr :orientation, :atom, values: [:vertical, :horizontal], default: :horizontal
+
+  attr :"phx-click", :any, default: nil
+  attr :"phx-target", :any, default: nil
 
   def area_plot(%{orientation: :horizontal} = assigns) do
     ~H"""
@@ -360,6 +399,18 @@ defmodule Plox do
         width={scalar2.value - scalar1.value}
         x={scalar1.value}
         y={@dataset.dimensions.margin.top}
+        phx-click={
+          if assigns[:"phx-click"],
+            do:
+              JS.push(assigns[:"phx-click"],
+                value: %{
+                  start_area_point_id: scalar1.data_point.id,
+                  end_area_point_id: scalar2.data_point.id,
+                  dataset_id: @dataset.id
+                }
+              )
+        }
+        phx-target={assigns[:"phx-target"]}
       />
     <% end %>
     """

--- a/lib/plox.ex
+++ b/lib/plox.ex
@@ -234,7 +234,14 @@ defmodule Plox do
       phx-click={
         if assigns[:"phx-click"],
           do:
-            JS.push(assigns[:"phx-click"], value: %{id: point.data_point.id, dataset_id: @dataset.id})
+            JS.push(assigns[:"phx-click"],
+              value: %{
+                id: point.data_point.id,
+                dataset_id: @dataset.id,
+                x_pixel: point.x,
+                y_pixel: point.y
+              }
+            )
       }
       phx-target={assigns[:"phx-target"]}
       style={if assigns[:"phx-click"], do: "cursor: pointer;"}
@@ -274,7 +281,12 @@ defmodule Plox do
           if assigns[:"phx-click"],
             do:
               JS.push(assigns[:"phx-click"],
-                value: %{id: point.data_point.id, dataset_id: @dataset.id}
+                value: %{
+                  id: point.data_point.id,
+                  dataset_id: @dataset.id,
+                  x_pixel: point.x,
+                  y_pixel: point.y
+                }
               )
         }
         phx-target={assigns[:"phx-target"]}
@@ -307,69 +319,32 @@ defmodule Plox do
   attr :x, :atom, default: :x, doc: "The dataset axis key to use for x values"
   attr :y, :atom, default: :y, doc: "The dataset axis key to use for y values"
 
+  attr :x_pixel, :any, required: true
+  attr :y_pixel, :any, required: true
+
   attr :"phx-click-away", :any
   attr :"phx-target", :any, default: nil
 
   slot :inner_block, required: true
 
   def tooltip(assigns) do
-    point = GraphDataset.to_graph_point(assigns.dataset, assigns.x, assigns.y, assigns.point_id)
-
-    assigns = assign(assigns, point: point)
+    assigns = assign(assigns, data_point: GraphDataset.get_point(assigns.dataset, assigns.point_id))
 
     ~H"""
     <div
       style={[
         "position: absolute; padding: 1rem; font-size: 0.75rem; background: #4B4C4D; color: #CACBCC; z-index: 10; border-radius: 0.75rem; transform: translate(-50%);",
-        "left: #{@point.x}px; bottom: #{@dataset.dimensions.height - @point.y + 12}px;",
+        "left: #{@x_pixel}px; bottom: #{@dataset.dimensions.height - @y_pixel + 12}px;",
         "box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1);"
       ]}
       phx-click-away={assigns[:"phx-click-away"]}
       phx-target={assigns[:"phx-target"]}
     >
-      <%= render_slot(@inner_block, @point.data_point.original) %>
+      <%= render_slot(@inner_block, @data_point.original) %>
       <div style="transform: translate(-50%) rotate(45deg); position: absolute; left: 50%; bottom: -0.5rem; width: 1rem; height: 1rem; z-index: -10; background: #4B4C4D" />
     </div>
     """
   end
-
-  # @doc """
-  # TODO:
-
-  # Tooltip based on manually passing y/y scales/values instead of inferring based on dataset.
-  # """
-  # @doc type: :component
-
-  # attr :x_scale, :any, required: true
-  # attr :y_scale, :any, required: true
-  # attr :x_value, :any, required: true
-  # attr :y_value, :any, required: true
-
-  # attr :"phx-click-away", :any
-  # attr :"phx-target", :any, default: nil
-
-  # slot :inner_block, required: true
-
-  # def coordinate_tooltip(assigns) do
-  #   point = GraphDataset.to_graph_point(assigns.dataset, assigns.x, assigns.y, assigns.point_id)
-
-  #   assigns = assign(assigns, point: point)
-
-  #   ~H"""
-  #   <div
-  #     style={[
-  #       "position: absolute; padding: 1rem; font-size: 0.75rem; background: #4B4C4D; color: #CACBCC; z-index: 10; border-radius: 0.75rem; transform: translate(-50%);",
-  #       "left: #{@point.x}px; bottom: #{@dataset.dimensions.height - @point.y + 12}px;",
-  #       "box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1);"
-  #     ]}
-  #     phx-click-away={assigns[:"phx-click-away"]}
-  #     phx-target={assigns[:"phx-target"]}
-  #   >
-  #     <%= render_slot(@inner_block, @point.data_point.original) %>
-  #     <div style="transform: translate(-50%) rotate(45deg); position: absolute; left: 50%; bottom: -0.5rem; width: 1rem; height: 1rem; z-index: -10; background: #4B4C4D" />
-  #   </div>
-  #   """
-  # end
 
   @doc """
   One-dimensional shaded areas, either horizontal or vertical
@@ -406,10 +381,13 @@ defmodule Plox do
                 value: %{
                   start_area_point_id: scalar1.data_point.id,
                   end_area_point_id: scalar2.data_point.id,
-                  dataset_id: @dataset.id
+                  dataset_id: @dataset.id,
+                  x_pixel: scalar1.value + (scalar2.value - scalar1.value) / 2,
+                  y_pixel: @dataset.dimensions.margin.top + @dataset.dimensions.height / 2
                 }
               )
         }
+        style={if assigns[:"phx-click"], do: "cursor: pointer;"}
         phx-target={assigns[:"phx-target"]}
       />
     <% end %>
@@ -429,6 +407,21 @@ defmodule Plox do
         }
         x={@dataset.dimensions.margin.left}
         y={scalar1.value - (scalar1.value - scalar2.value)}
+        phx-click={
+          if assigns[:"phx-click"],
+            do:
+              JS.push(assigns[:"phx-click"],
+                value: %{
+                  start_area_point_id: scalar1.data_point.id,
+                  end_area_point_id: scalar2.data_point.id,
+                  dataset_id: @dataset.id,
+                  x_pixel: @dataset.dimensions.margin.left + @dataset.dimensions.width / 2,
+                  y_pixel: scalar2.value + (scalar1.value - scalar2.value) / 2
+                }
+              )
+        }
+        style={if assigns[:"phx-click"], do: "cursor: pointer;"}
+        phx-target={assigns[:"phx-target"]}
       />
     <% end %>
     """

--- a/lib/plox/graph_dataset.ex
+++ b/lib/plox/graph_dataset.ex
@@ -6,6 +6,7 @@ defmodule Plox.GraphDataset do
 
   alias Plox.ColorScale
   alias Plox.DataPoint
+  alias Plox.GraphPoint
   alias Plox.GraphScale
 
   defstruct [:id, :dataset, :dimensions]
@@ -35,15 +36,40 @@ defmodule Plox.GraphDataset do
   end
 
   def to_graph_point(%__MODULE__{} = dataset, x_key, y_key, id) do
-    x_scale = get_scale!(dataset, x_key)
-    y_scale = get_scale!(dataset, y_key)
+    case Map.fetch(dataset.dataset.scales, y_key) do
+      {:ok, _} ->
+        x_scale = get_scale!(dataset, x_key)
+        y_scale = get_scale!(dataset, y_key)
 
-    Enum.find_value(dataset.dataset.data, fn data_point ->
-      if data_point.id == id do
-        DataPoint.to_graph_point(data_point, x_scale, x_key, y_scale, y_key)
-      end
-    end)
+        Enum.find_value(dataset.dataset.data, fn data_point ->
+          if data_point.id == id do
+            DataPoint.to_graph_point(data_point, x_scale, x_key, y_scale, y_key)
+          end
+        end)
+
+      :error ->
+        x_scale = get_scale!(dataset, x_key)
+
+        Enum.find_value(dataset.dataset.data, fn data_point ->
+          if data_point.id == id do
+            graph_x = DataPoint.to_graph_x(data_point, x_scale, x_key)
+
+            GraphPoint.new(graph_x.value, dataset.dimensions.height / 2, data_point)
+          end
+        end)
+    end
   end
+
+  # def to_graph_point(%__MODULE__{} = dataset, x_key, y_key, id) do
+  #   x_scale = get_scale!(dataset, x_key)
+  #   y_scale = get_scale!(dataset, y_key)
+
+  #   Enum.find_value(dataset.dataset.data, fn data_point ->
+  #     if data_point.id == id do
+  #       DataPoint.to_graph_point(data_point, x_scale, x_key, y_scale, y_key)
+  #     end
+  #   end)
+  # end
 
   def to_graph_xs(%__MODULE__{} = dataset, x_key) do
     x_scale = get_scale!(dataset, x_key)

--- a/lib/plox/graph_dataset.ex
+++ b/lib/plox/graph_dataset.ex
@@ -6,13 +6,18 @@ defmodule Plox.GraphDataset do
 
   alias Plox.ColorScale
   alias Plox.DataPoint
-  alias Plox.GraphPoint
   alias Plox.GraphScale
 
   defstruct [:id, :dataset, :dimensions]
 
   def new(id, dataset, dimensions) do
     %__MODULE__{id: id, dataset: dataset, dimensions: dimensions}
+  end
+
+  def get_point(dataset, point_id) do
+    Enum.find_value(dataset.dataset.data, fn data_point ->
+      if data_point.id == point_id, do: data_point
+    end)
   end
 
   def get_scale!(%__MODULE__{dataset: dataset, dimensions: dimensions}, key) do
@@ -36,40 +41,15 @@ defmodule Plox.GraphDataset do
   end
 
   def to_graph_point(%__MODULE__{} = dataset, x_key, y_key, id) do
-    case Map.fetch(dataset.dataset.scales, y_key) do
-      {:ok, _} ->
-        x_scale = get_scale!(dataset, x_key)
-        y_scale = get_scale!(dataset, y_key)
+    x_scale = get_scale!(dataset, x_key)
+    y_scale = get_scale!(dataset, y_key)
 
-        Enum.find_value(dataset.dataset.data, fn data_point ->
-          if data_point.id == id do
-            DataPoint.to_graph_point(data_point, x_scale, x_key, y_scale, y_key)
-          end
-        end)
-
-      :error ->
-        x_scale = get_scale!(dataset, x_key)
-
-        Enum.find_value(dataset.dataset.data, fn data_point ->
-          if data_point.id == id do
-            graph_x = DataPoint.to_graph_x(data_point, x_scale, x_key)
-
-            GraphPoint.new(graph_x.value, dataset.dimensions.height / 2, data_point)
-          end
-        end)
-    end
+    Enum.find_value(dataset.dataset.data, fn data_point ->
+      if data_point.id == id do
+        DataPoint.to_graph_point(data_point, x_scale, x_key, y_scale, y_key)
+      end
+    end)
   end
-
-  # def to_graph_point(%__MODULE__{} = dataset, x_key, y_key, id) do
-  #   x_scale = get_scale!(dataset, x_key)
-  #   y_scale = get_scale!(dataset, y_key)
-
-  #   Enum.find_value(dataset.dataset.data, fn data_point ->
-  #     if data_point.id == id do
-  #       DataPoint.to_graph_point(data_point, x_scale, x_key, y_scale, y_key)
-  #     end
-  #   end)
-  # end
 
   def to_graph_xs(%__MODULE__{} = dataset, x_key) do
     x_scale = get_scale!(dataset, x_key)


### PR DESCRIPTION
This PR adds functionality to click on an `area_plot` and show a tooltip.

It also changes tooltip rendering logic to utilize `x_pixel` and `y_pixel` instead of inferring the pixel coordinates from the passed `dataset` and `point_id`