### PR TITLE
Simplify the way we generate multiple values from datasets

### DIFF
--- a/animated_demo_live.exs
+++ b/animated_demo_live.exs
@@ -100,9 +100,9 @@ defmodule AnimatedDemoLive do
 
       <.x_axis_grid_line axis={@x_axis} value={@now} stroke="red" />
 
-      <.polyline points={Enum.zip(@dataset1[:x], @dataset1[:y])} stroke="orange" stroke-width="2" />
-      <.polyline points={Enum.zip(@dataset2[:x], @dataset2[:y])} stroke="blue" stroke-width="2" />
-      <.polyline points={Enum.zip(@dataset3[:x], @dataset3[:y])} stroke="green" stroke-width="2" />
+      <.polyline points={points(@dataset1[:x], @dataset1[:y])} stroke="orange" stroke-width="2" />
+      <.polyline points={points(@dataset2[:x], @dataset2[:y])} stroke="blue" stroke-width="2" />
+      <.polyline points={points(@dataset3[:x], @dataset3[:y])} stroke="green" stroke-width="2" />
       <%!-- <.circles dataset={@points_dataset} r={:r} fill={:color} /> --%>
     </.graph>
     """

--- a/lib/plox.ex
+++ b/lib/plox.ex
@@ -398,7 +398,7 @@ defmodule Plox do
     |> Enum.uniq()
     |> case do
       [] -> :none
-      [dataset] -> dataset
+      [_dataset] -> :ok
       _ -> raise "all dynamic values must be from the same dataset"
     end
   end
@@ -412,7 +412,7 @@ defmodule Plox do
       :none ->
         [List.to_tuple(data)]
 
-      _dataset ->
+      :ok ->
         enumerables =
           data
           |> Enum.map(fn


### PR DESCRIPTION
My proposal for a "value generator" function (with simple helper `points`).  The idea is that many graphing components are going to need to generate values from datasets.  Sometimes you want to do this internal to the library (see the `circle` component).  Sometimes you want to let the user use the value generator directly (see the polyline example in the phoenix playground).  I think this is simple and elegant.  Thoughts?