### PR TITLE
Support sticky left and right axes

### DIFF
--- a/lib/plox.ex
+++ b/lib/plox.ex
@@ -51,6 +51,8 @@ defmodule Plox do
 
   slot :legend
   slot :tooltips
+  slot :sticky_left_axis, doc: "Y-axes included in this slot will stick to the left of the graph"
+  slot :sticky_right_axis, doc: "Y-axes included in this slot will stick to the right of the graph"
   slot :inner_block, required: true
 
   def graph(assigns) do
@@ -78,9 +80,21 @@ defmodule Plox do
         </.legend>
       </div>
       <div style={@graph_div_style_string}>
+        <%= for sticky_left_axis <- @sticky_left_axis do %>
+          <div style="display: flex; flex-direction: column-reverse; justify-content: space-evenly; position: sticky; left: 0px; margin-top: 4px; margin-bottom: 16px;">
+            {render_slot(sticky_left_axis, @graph)}
+          </div>
+        <% end %>
+
         <svg viewBox={"0 0 #{@width} #{@height}"} xmlns="http://www.w3.org/2000/svg">
           {render_slot(@inner_block, @graph)}
         </svg>
+
+        <%= for sticky_right_axis <- @sticky_right_axis do %>
+          <div style="display: flex; flex-direction: column-reverse; justify-content: space-evenly; position: sticky; right: 0px; margin-top: 4px; margin-bottom: 16px;">
+            {render_slot(sticky_right_axis, @graph)}
+          </div>
+        <% end %>
 
         <%= for tooltip <- @tooltips do %>
           {render_slot(tooltip, @graph)}

--- a/lib/plox.ex
+++ b/lib/plox.ex
@@ -80,21 +80,17 @@ defmodule Plox do
         </.legend>
       </div>
       <div style={@graph_div_style_string}>
-        <%= for sticky_left_axis <- @sticky_left_axis do %>
-          <div style="display: flex; flex-direction: column-reverse; justify-content: space-evenly; position: sticky; left: 0px; margin-top: 4px; margin-bottom: 16px;">
-            {render_slot(sticky_left_axis, @graph)}
-          </div>
-        <% end %>
+        <div style="display: flex; flex-direction: column-reverse; justify-content: space-evenly; position: sticky; left: 0px; margin-top: 4px; margin-bottom: 16px;">
+          {render_slot(@sticky_left_axis, @graph)}
+        </div>
 
         <svg viewBox={"0 0 #{@width} #{@height}"} xmlns="http://www.w3.org/2000/svg">
           {render_slot(@inner_block, @graph)}
         </svg>
 
-        <%= for sticky_right_axis <- @sticky_right_axis do %>
-          <div style="display: flex; flex-direction: column-reverse; justify-content: space-evenly; position: sticky; right: 0px; margin-top: 4px; margin-bottom: 16px;">
-            {render_slot(sticky_right_axis, @graph)}
-          </div>
-        <% end %>
+        <div style="display: flex; flex-direction: column-reverse; justify-content: space-evenly; position: sticky; right: 0px; margin-top: 4px; margin-bottom: 16px;">
+          {render_slot(@sticky_right_axis, @graph)}
+        </div>
 
         <%= for tooltip <- @tooltips do %>
           {render_slot(tooltip, @graph)}

--- a/lib/plox.ex
+++ b/lib/plox.ex
@@ -80,8 +80,10 @@ defmodule Plox do
         </.legend>
       </div>
       <div style={@graph_div_style_string}>
-
-        <div :if={@sticky_left_axis != []} style="display: flex; flex-direction: column-reverse; justify-content: space-evenly; position: sticky; left: 0px; margin-top: 4px; margin-bottom: 16px;">
+        <div
+          :if={@sticky_left_axis != []}
+          style="display: flex; flex-direction: column-reverse; justify-content: space-evenly; position: sticky; left: 0px; margin-top: 4px; margin-bottom: 16px;"
+        >
           {render_slot(@sticky_left_axis, @graph)}
         </div>
 
@@ -89,7 +91,10 @@ defmodule Plox do
           {render_slot(@inner_block, @graph)}
         </svg>
 
-        <div :if={@sticky_right_axis != []} style="display: flex; flex-direction: column-reverse; justify-content: space-evenly; position: sticky; right: 0px; margin-top: 4px; margin-bottom: 16px;">
+        <div
+          :if={@sticky_right_axis != []}
+          style="display: flex; flex-direction: column-reverse; justify-content: space-evenly; position: sticky; right: 0px; margin-top: 4px; margin-bottom: 16px;"
+        >
           {render_slot(@sticky_right_axis, @graph)}
         </div>
 

--- a/lib/plox.ex
+++ b/lib/plox.ex
@@ -80,7 +80,8 @@ defmodule Plox do
         </.legend>
       </div>
       <div style={@graph_div_style_string}>
-        <div style="display: flex; flex-direction: column-reverse; justify-content: space-evenly; position: sticky; left: 0px; margin-top: 4px; margin-bottom: 16px;">
+
+        <div :if={@sticky_left_axis != []} style="display: flex; flex-direction: column-reverse; justify-content: space-evenly; position: sticky; left: 0px; margin-top: 4px; margin-bottom: 16px;">
           {render_slot(@sticky_left_axis, @graph)}
         </div>
 
@@ -88,7 +89,7 @@ defmodule Plox do
           {render_slot(@inner_block, @graph)}
         </svg>
 
-        <div style="display: flex; flex-direction: column-reverse; justify-content: space-evenly; position: sticky; right: 0px; margin-top: 4px; margin-bottom: 16px;">
+        <div :if={@sticky_right_axis != []} style="display: flex; flex-direction: column-reverse; justify-content: space-evenly; position: sticky; right: 0px; margin-top: 4px; margin-bottom: 16px;">
           {render_slot(@sticky_right_axis, @graph)}
         </div>
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Plox.MixProject do
   use Mix.Project
 
-  @version "0.3.1"
+  @version "0.3.2"
   @source_url "https://github.com/gridpoint-com/plox"
 
   def project do


### PR DESCRIPTION
This PR adds 2 new slots: `sticky_left_axis` and `sticky_right_axis`. These when used with a `y_axis` component within allow a user to specify that an axis should stick to the left or right of the graph.

Usage examples:

```
<:sticky_left_axis :let={graph}>
  <.y_axis :let={value} ...>{round(value)}°</.y_axis>
</:sticky_left_axis>

<:sticky_right_axis :let={graph}>
  <.y_axis :let={value}  position={:right} ...>{value}</.y_axis>
</:sticky_right_axis>
```

Screenshot of examples. Note that scrollbar is in the middle of the graph and axes are both visible:
<img width="1650" height="696" alt="Screenshot 2026-06-04 at 1 25 23 PM" src="https://github.com/user-attachments/assets/53b966cc-db4a-47da-ad31-30d277cf6e6e" />